### PR TITLE
Remove config.getRegion() when obtaining configserver

### DIFF
--- a/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
+++ b/spring-cloud-netflix-eureka-client/src/main/java/org/springframework/cloud/netflix/eureka/config/EurekaConfigServerInstanceProvider.java
@@ -53,7 +53,7 @@ public class EurekaConfigServerInstanceProvider {
 		if (log.isDebugEnabled()) {
 			log.debug("eurekaConfigServerInstanceProvider finding instances for " + serviceId);
 		}
-		EurekaHttpResponse<Applications> response = client.getApplications(config.getRegion());
+		EurekaHttpResponse<Applications> response = client.getApplications();
 		List<ServiceInstance> instances = new ArrayList<>();
 		if (!isSuccessful(response) || response.getEntity() == null) {
 			return instances;


### PR DESCRIPTION
The parameter `regions`in the `client.getApplications ()` method represents remoteRegions, which indicates that the registry should not only retrieve and return a list of its own nodes, but also return a list of remoteRegions.

But `config.getRegion()` represents the local region, and if this parameter is included, the registry will continue to print:
`No remote registry available for the remote region xxx`